### PR TITLE
feat: implement responder management screens

### DIFF
--- a/admin-panel/src/navigation/AppRouter.tsx
+++ b/admin-panel/src/navigation/AppRouter.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../contexts/AuthContext";
 import Layout from "../components/layout/Layout";
 import LoginScreen from "../screens/auth/LoginScreen";
 import DashboardScreen from "../screens/dashboard/DashboardScreen";
-import ResponderListScreen from "../screens/responders/ResponderListScreen";
+import ResponderListScreen from "../screens/responders/ResponderListscreen";
 import ResponderCreateScreen from "../screens/responders/ResponderCreateScreen";
 import ResponderDetailScreen from "../screens/responders/ResponderDetailScreen";
 

--- a/admin-panel/src/screens/responders/ResponderCreateScreen.tsx
+++ b/admin-panel/src/screens/responders/ResponderCreateScreen.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  MenuItem,
+  Alert,
+} from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import api from "../../api/axios";
+
+interface ResponderFormData {
+  name: string;
+  email: string;
+  expertise: string;
+  password: string;
+}
+
+const EXPERTISE_OPTIONS = [
+  "Biblical Studies",
+  "Theology",
+  "Church History",
+  "Pastoral Care",
+  "Ethics",
+];
+
+const ResponderCreateScreen = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<ResponderFormData>({
+    name: "",
+    email: "",
+    expertise: "",
+    password: "",
+  });
+  const [error, setError] = useState<string>("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await api.post("/admin/responders", formData);
+      navigate("/responders");
+    } catch (error: any) {
+      setError(error.response?.data?.message || "Failed to create responder");
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Create Responder
+      </Typography>
+
+      <Paper sx={{ p: 3, maxWidth: 600 }}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                required
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                select
+                label="Expertise"
+                name="expertise"
+                value={formData.expertise}
+                onChange={handleChange}
+                required
+              >
+                {EXPERTISE_OPTIONS.map((option) => (
+                  <MenuItem key={option} value={option}>
+                    {option}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Grid>
+
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Initial Password"
+                name="password"
+                type="password"
+                value={formData.password}
+                onChange={handleChange}
+                required
+                helperText="Responder will be required to change this on first login"
+              />
+            </Grid>
+
+            <Grid item xs={12} sx={{ display: "flex", gap: 2 }}>
+              <Button variant="contained" type="submit" size="large">
+                Create Responder
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => navigate("/responders")}
+                size="large"
+              >
+                Cancel
+              </Button>
+            </Grid>
+          </Grid>
+        </form>
+      </Paper>
+    </Box>
+  );
+};
+
+export default ResponderCreateScreen;

--- a/admin-panel/src/screens/responders/ResponderDetailScreen.tsx
+++ b/admin-panel/src/screens/responders/ResponderDetailScreen.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  MenuItem,
+  Alert,
+  Switch,
+  FormControlLabel,
+} from "@mui/material";
+import { useNavigate, useParams } from "react-router-dom";
+import api from "../../api/axios";
+
+interface ResponderDetail {
+  id: string;
+  name: string;
+  email: string;
+  expertise: string;
+  status: "active" | "inactive";
+  questionsAnswered: number;
+  lastActive: string;
+}
+
+const EXPERTISE_OPTIONS = [
+  "Biblical Studies",
+  "Theology",
+  "Church History",
+  "Pastoral Care",
+  "Ethics",
+];
+
+const ResponderDetailScreen = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [responder, setResponder] = useState<ResponderDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>("");
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    loadResponder();
+  }, [id]);
+
+  const loadResponder = async () => {
+    try {
+      const response = await api.get(`/admin/responders/${id}`);
+      setResponder(response.data);
+    } catch (error: any) {
+      setError("Failed to load responder details");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    try {
+      await api.put(`/admin/responders/${id}`, responder);
+      setIsEditing(false);
+      loadResponder();
+    } catch (error: any) {
+      setError(error.response?.data?.message || "Failed to update responder");
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (responder) {
+      setResponder({
+        ...responder,
+        [e.target.name]: e.target.value,
+      });
+    }
+  };
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (responder) {
+      setResponder({
+        ...responder,
+        status: e.target.checked ? "active" : "inactive",
+      });
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+  if (!responder) return <div>Responder not found</div>;
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
+        <Typography variant="h4">Responder Details</Typography>
+        <Button variant="contained" onClick={() => setIsEditing(!isEditing)}>
+          {isEditing ? "Cancel Edit" : "Edit Details"}
+        </Button>
+      </Box>
+
+      <Paper sx={{ p: 3 }}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="Name"
+              name="name"
+              value={responder.name}
+              onChange={handleChange}
+              disabled={!isEditing}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="Email"
+              name="email"
+              value={responder.email}
+              onChange={handleChange}
+              disabled={!isEditing}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              select
+              label="Expertise"
+              name="expertise"
+              value={responder.expertise}
+              onChange={handleChange}
+              disabled={!isEditing}
+            >
+              {EXPERTISE_OPTIONS.map((option) => (
+                <MenuItem key={option} value={option}>
+                  {option}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={responder.status === "active"}
+                  onChange={handleStatusChange}
+                  disabled={!isEditing}
+                />
+              }
+              label="Active Status"
+            />
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <Typography variant="body2" color="text.secondary">
+              Questions Answered: {responder.questionsAnswered}
+            </Typography>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <Typography variant="body2" color="text.secondary">
+              Last Active: {new Date(responder.lastActive).toLocaleString()}
+            </Typography>
+          </Grid>
+
+          {isEditing && (
+            <Grid item xs={12} sx={{ mt: 2 }}>
+              <Button variant="contained" onClick={handleUpdate} sx={{ mr: 2 }}>
+                Save Changes
+              </Button>
+              <Button variant="outlined" onClick={() => setIsEditing(false)}>
+                Cancel
+              </Button>
+            </Grid>
+          )}
+        </Grid>
+      </Paper>
+    </Box>
+  );
+};
+
+export default ResponderDetailScreen;

--- a/admin-panel/src/screens/responders/ResponderListScreen.tsx
+++ b/admin-panel/src/screens/responders/ResponderListScreen.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Paper,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Chip,
+  IconButton,
+} from "@mui/material";
+import { Add as AddIcon, Edit as EditIcon } from "@mui/icons-material";
+import { useNavigate } from "react-router-dom";
+import api from "../../api/axios";
+
+interface Responder {
+  id: string;
+  name: string;
+  email: string;
+  expertise: string;
+  status: "active" | "inactive";
+  questionsAnswered: number;
+  lastActive: string;
+}
+
+const ResponderListScreen = () => {
+  const [responders, setResponders] = useState<Responder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    loadResponders();
+  }, []);
+
+  const loadResponders = async () => {
+    try {
+      const response = await api.get("/admin/responders");
+      setResponders(response.data);
+    } catch (error) {
+      console.error("Failed to load responders:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
+        <Typography variant="h4">Responders</Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => navigate("/responders/create")}
+        >
+          Add Responder
+        </Button>
+      </Box>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Expertise</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Questions Answered</TableCell>
+              <TableCell>Last Active</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {responders.map((responder) => (
+              <TableRow key={responder.id}>
+                <TableCell>{responder.name}</TableCell>
+                <TableCell>{responder.email}</TableCell>
+                <TableCell>{responder.expertise}</TableCell>
+                <TableCell>
+                  <Chip
+                    label={responder.status}
+                    color={
+                      responder.status === "active" ? "success" : "default"
+                    }
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell>{responder.questionsAnswered}</TableCell>
+                <TableCell>
+                  {new Date(responder.lastActive).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  <IconButton
+                    onClick={() => navigate(`/responders/${responder.id}`)}
+                    size="small"
+                  >
+                    <EditIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default ResponderListScreen;


### PR DESCRIPTION
# Implement Responder Management Screens

## Changes
- Added ResponderListScreen with table view
- Implemented ResponderCreateScreen with form
- Created ResponderDetailScreen with edit functionality
- Added responder status management
- Implemented expertise selection

## Technical Details
- Material UI components for forms and tables
- Real-time data updates
- Status toggle functionality
- Form validation and error handling